### PR TITLE
fix typos in github actions

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -28,14 +28,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Run ERC
+    - name: Run DRC
       run: |
         [ -f *.sch ] && kibot -s update_xml,run_drc -i
 
     - name: Retrieve results
       uses: actions/upload-artifact@v1
       with:
-        name: ERC_Output
+        name: DRC_Output
         path: build
 
   DRC:
@@ -46,14 +46,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Run DRC
+    - name: Run ERC
       run: |
         [ -f *.kicad_pcb ] && kibot -s update_xml,run_erc -i
 
     - name: Retrieve results
       uses: actions/upload-artifact@v1
       with:
-        name: DRC_Output
+        name: ERC_Output
         path: build
 
   FabSch:


### PR DESCRIPTION
jobs names and output of DRC and ERC were switched.

Unless `run_drc` and `run_erc` don't mean what I think they mean.. 🙃 